### PR TITLE
fix: handle preloaded batches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ The next example works fine, as `:delete_post` action doesn't use dataloader:
 ```elixir
 Datacop.permit(MyApp.Blog.Policy, :delete_post, actor, subject: post)
 ```
+With `Datacop.permit?/4` it's also possible to work with booleans:
+```elixir
+Datacop.permit?(MyApp.Blog, :search, actor, loader: loader)}
+```
 
 ### Use as Absinthe middleware
 In order to leverage full potential of `datacop` it is recommended to use it with `absinthe`.


### PR DESCRIPTION
This commit fixes the error when we are trying to preload data with the same batch key twice.

```
** (exit) an exception was raised:
    ** (RuntimeError) Found unresolved resolution struct!

You probably forgot to run the resolution phase again.
...
```

Dataloader.Ecto.run/1 checks pending batches
(see https://github.com/absinthe-graphql/dataloader/blob/master/lib/dataloader.ex#L144).
In case there is no pending batches, it returns dataloader struct, otherwise it runs the Dataloader.
That is why there is no need to suspend the resolution without pending batches, so there is no need to
run `on_load/4` callback to get results.